### PR TITLE
new gameobject stuff

### DIFF
--- a/drivers/test_render.c
+++ b/drivers/test_render.c
@@ -208,9 +208,9 @@ int main(){
         }
 
         render_begin(active_cam);
-        render_rmodel(gun_model,WHITE);
-        //render_rmodel(sphere_rmodel,WHITE);
-        //render_rmodel(plane_model,WHITE);
+        //render_rmodel(gun_model,WHITE);
+        render_rmodel(sphere_rmodel,WHITE);
+        render_rmodel(plane_model,WHITE);
 
         if (draw_grid){
             render_draw_grid(100,1.0f);

--- a/project/prefabs/lightmanager.prefab
+++ b/project/prefabs/lightmanager.prefab
@@ -1,0 +1,2 @@
+prefabName = lightmanager
+prefabScripts = lightmanager

--- a/project/prefabs/testPrefab.prefab
+++ b/project/prefabs/testPrefab.prefab
@@ -1,3 +1,3 @@
 prefabName = testPrefab
 prefabModel = SPHERE
-prefabScripts = test,test1
+prefabScripts = test,test2

--- a/project/scenes/testScene.scene
+++ b/project/scenes/testScene.scene
@@ -1,4 +1,7 @@
 sceneName = testScene
-scenePrefabs = /Users/humzaqureshi/GitHub/Flux-Engine/project/prefabs/defaultCamera.prefab,/Users/humzaqureshi/GitHub/Flux-Engine/project/prefabs/testPrefab.prefab
+scenePrefabs = /Users/humzaqureshi/GitHub/Flux-Engine/project/prefabs/defaultCamera.prefab,/Users/humzaqureshi/GitHub/Flux-Engine/project/prefabs/testPrefab.prefab,/Users/humzaqureshi/GitHub/Flux-Engine/project/prefabs/lightmanager.prefab
 sceneGameObject = defaultCamera,0,0,-10,0,0,0,1,1,1
 sceneGameObject = testPrefab,0,0,0,0,0,0,1,1,1
+sceneGameObject = testPrefab,2,0,0,0,0,0,1,1,1
+sceneGameObject = testPrefab,-2,0,0,0,0,0,1,1,1
+sceneGameObject = lightmanager,0,0,0,0,0,0,1,1,1

--- a/project/scenes/testScene.scene
+++ b/project/scenes/testScene.scene
@@ -4,4 +4,4 @@ sceneGameObject = defaultCamera,0,0,-10,0,0,0,1,1,1
 sceneGameObject = testPrefab,0,0,0,0,0,0,1,1,1
 sceneGameObject = testPrefab,2,0,0,0,0,0,1,1,1
 sceneGameObject = testPrefab,-2,0,0,0,0,0,1,1,1
-sceneGameObject = lightmanager,0,0,0,0,0,0,1,1,1
+sceneGameObject = lightmanager,0,0,0,0,0,0,1,1,1,ka: 0.2

--- a/project/scenes/testScene.scene
+++ b/project/scenes/testScene.scene
@@ -4,4 +4,4 @@ sceneGameObject = defaultCamera,0,0,-10,0,0,0,1,1,1
 sceneGameObject = testPrefab,0,0,0,0,0,0,1,1,1
 sceneGameObject = testPrefab,2,0,0,0,0,0,1,1,1
 sceneGameObject = testPrefab,-2,0,0,0,0,0,1,1,1
-sceneGameObject = lightmanager,0,0,0,0,0,0,1,1,1,ka: 0.2
+sceneGameObject = lightmanager,0,0,0,0,0,0,1,1,1,ka:0.2,skybox:drivers/assets/Daylight Box UV.png

--- a/project/scripts/lightmanager.c
+++ b/project/scripts/lightmanager.c
@@ -1,13 +1,12 @@
-#define SCRIPT test
+#define SCRIPT lightmanager
 #include "fluxScript.h"
 
 script_data{
-    int x;
+
 };
 
 fluxCallback onInit(fluxGameObject obj, script_data* data){
-    data->x = 0;
-    /*render_set_ka(0.2);
+    render_set_ka(0.2);
     render_light_enable(0);
     render_light_set_type(0,0);
     render_light_set_cL(0,WHITE);
@@ -22,10 +21,9 @@ fluxCallback onInit(fluxGameObject obj, script_data* data){
     render_light_set_kd(1,0.7);
     render_light_set_ks(1,0.3);
     render_light_set_L(1,(Vector3){0,2,-1});
-    render_light_set_p(1,200);*/
+    render_light_set_p(1,200);
 }
 
 fluxCallback onUpdate(fluxGameObject obj, script_data* data){
-    //TraceLog(LOG_INFO,"UPDATE...");
-    data->x++;
+
 }

--- a/project/scripts/lightmanager.c
+++ b/project/scripts/lightmanager.c
@@ -2,11 +2,12 @@
 #include "fluxScript.h"
 
 script_data{
-
+    float ka;
 };
 
-fluxCallback onInit(fluxGameObject obj, script_data* data){
-    render_set_ka(0.2);
+fluxCallback onInit(fluxGameObject obj, script_data* data, hstrArray args){
+    data->ka = 0.2;
+    //render_set_ka(0.2);
     render_light_enable(0);
     render_light_set_type(0,0);
     render_light_set_cL(0,WHITE);
@@ -22,6 +23,23 @@ fluxCallback onInit(fluxGameObject obj, script_data* data){
     render_light_set_ks(1,0.3);
     render_light_set_L(1,(Vector3){0,2,-1});
     render_light_set_p(1,200);
+
+    for (int i = 0; i < hstr_array_len(args); i++){
+        hstr arg = hstr_incref(hstr_array_get(args,i));
+        hstrArray split = hstr_split(arg,":");
+        if (hstr_array_len(split) == 2){
+            const char* argument = hstr_unpack(hstr_array_get(split,0));
+            const char* value = hstr_unpack(hstr_array_get(split,1));
+            if (strcmp(argument,"ka") == 0){
+                data->ka = atof(value);
+                TraceLog(LOG_INFO,"ka = %g",data->ka);
+            }
+        }
+        hstr_array_delete(split);
+        hstr_decref(arg);
+    }
+
+    render_set_ka(data->ka);
 }
 
 fluxCallback onUpdate(fluxGameObject obj, script_data* data){

--- a/project/scripts/lightmanager.c
+++ b/project/scripts/lightmanager.c
@@ -34,6 +34,9 @@ fluxCallback onInit(fluxGameObject obj, script_data* data, hstrArray args){
                 data->ka = atof(value);
                 TraceLog(LOG_INFO,"ka = %g",data->ka);
             }
+            if (strcmp(argument,"skybox") == 0){
+                render_load_skybox(value);
+            }
         }
         hstr_array_delete(split);
         hstr_decref(arg);

--- a/project/scripts/test.c
+++ b/project/scripts/test.c
@@ -2,30 +2,18 @@
 #include "fluxScript.h"
 
 script_data{
-    int x;
+    fluxTransform transform;
 };
 
-fluxCallback onInit(fluxGameObject obj, script_data* data){
-    data->x = 0;
-    /*render_set_ka(0.2);
-    render_light_enable(0);
-    render_light_set_type(0,0);
-    render_light_set_cL(0,WHITE);
-    render_light_set_kd(0,0.7);
-    render_light_set_ks(0,0.3);
-    render_light_set_L(0,Vector3One());
-    render_light_set_p(0,200);
-
-    render_light_enable(1);
-    render_light_set_type(1,0);
-    render_light_set_cL(1,WHITE);
-    render_light_set_kd(1,0.7);
-    render_light_set_ks(1,0.3);
-    render_light_set_L(1,(Vector3){0,2,-1});
-    render_light_set_p(1,200);*/
+fluxCallback onInit(fluxGameObject obj, script_data* data, hstrArray args){
+    data->transform = flux_gameobject_get_transform(obj);
 }
 
 fluxCallback onUpdate(fluxGameObject obj, script_data* data){
     //TraceLog(LOG_INFO,"UPDATE...");
-    data->x++;
+    if (IsKeyDown(KEY_A))
+        data->transform.pos.x += GetFrameTime();
+    if (IsKeyDown(KEY_D))
+        data->transform.pos.x -= GetFrameTime();
+    flux_gameobject_set_transform(obj,data->transform);
 }

--- a/project/scripts/test2.c
+++ b/project/scripts/test2.c
@@ -5,7 +5,7 @@ script_data{
     float y;
 };
 
-fluxCallback onInit(fluxGameObject obj, script_data* data){
+fluxCallback onInit(fluxGameObject obj, script_data* data, hstrArray args){
     data->y = 0;
 }
 

--- a/project/scripts/test2.c
+++ b/project/scripts/test2.c
@@ -8,3 +8,8 @@ script_data{
 fluxCallback onInit(fluxGameObject obj, script_data* data){
     data->y = 0;
 }
+
+fluxCallback onUpdate(fluxGameObject obj, script_data* data){
+    //TraceLog(LOG_INFO,"update2");
+    data->y = 0;
+}

--- a/src/engine/GENERATED_SCRIPTS.h
+++ b/src/engine/GENERATED_SCRIPTS.h
@@ -67,6 +67,9 @@ fluxCallback onInit(fluxGameObject obj, script_data* data, hstrArray args){
                 data->ka = atof(value);
                 TraceLog(LOG_INFO,"ka = %g",data->ka);
             }
+            if (strcmp(argument,"skybox") == 0){
+                render_load_skybox(value);
+            }
         }
         hstr_array_delete(split);
         hstr_decref(arg);

--- a/src/engine/GENERATED_SCRIPTS.h
+++ b/src/engine/GENERATED_SCRIPTS.h
@@ -10,32 +10,20 @@ struct test2_fluxData;
 #include "fluxScript.h"
 
 script_data{
-    int x;
+    fluxTransform transform;
 };
 
-fluxCallback onInit(fluxGameObject obj, script_data* data){
-    data->x = 0;
-    /*render_set_ka(0.2);
-    render_light_enable(0);
-    render_light_set_type(0,0);
-    render_light_set_cL(0,WHITE);
-    render_light_set_kd(0,0.7);
-    render_light_set_ks(0,0.3);
-    render_light_set_L(0,Vector3One());
-    render_light_set_p(0,200);
-
-    render_light_enable(1);
-    render_light_set_type(1,0);
-    render_light_set_cL(1,WHITE);
-    render_light_set_kd(1,0.7);
-    render_light_set_ks(1,0.3);
-    render_light_set_L(1,(Vector3){0,2,-1});
-    render_light_set_p(1,200);*/
+fluxCallback onInit(fluxGameObject obj, script_data* data, hstrArray args){
+    data->transform = flux_gameobject_get_transform(obj);
 }
 
 fluxCallback onUpdate(fluxGameObject obj, script_data* data){
     //TraceLog(LOG_INFO,"UPDATE...");
-    data->x++;
+    if (IsKeyDown(KEY_A))
+        data->transform.pos.x += GetFrameTime();
+    if (IsKeyDown(KEY_D))
+        data->transform.pos.x -= GetFrameTime();
+    flux_gameobject_set_transform(obj,data->transform);
 }
 
 fluxCallback afterUpdate(fluxGameObject obj, script_data* data){}
@@ -47,11 +35,12 @@ fluxCallback onDraw2D(fluxGameObject obj, script_data* data){}
 #include "fluxScript.h"
 
 script_data{
-
+    float ka;
 };
 
-fluxCallback onInit(fluxGameObject obj, script_data* data){
-    render_set_ka(0.2);
+fluxCallback onInit(fluxGameObject obj, script_data* data, hstrArray args){
+    data->ka = 0.2;
+    //render_set_ka(0.2);
     render_light_enable(0);
     render_light_set_type(0,0);
     render_light_set_cL(0,WHITE);
@@ -67,6 +56,23 @@ fluxCallback onInit(fluxGameObject obj, script_data* data){
     render_light_set_ks(1,0.3);
     render_light_set_L(1,(Vector3){0,2,-1});
     render_light_set_p(1,200);
+
+    for (int i = 0; i < hstr_array_len(args); i++){
+        hstr arg = hstr_incref(hstr_array_get(args,i));
+        hstrArray split = hstr_split(arg,":");
+        if (hstr_array_len(split) == 2){
+            const char* argument = hstr_unpack(hstr_array_get(split,0));
+            const char* value = hstr_unpack(hstr_array_get(split,1));
+            if (strcmp(argument,"ka") == 0){
+                data->ka = atof(value);
+                TraceLog(LOG_INFO,"ka = %g",data->ka);
+            }
+        }
+        hstr_array_delete(split);
+        hstr_decref(arg);
+    }
+
+    render_set_ka(data->ka);
 }
 
 fluxCallback onUpdate(fluxGameObject obj, script_data* data){
@@ -85,7 +91,7 @@ script_data{
     float y;
 };
 
-fluxCallback onInit(fluxGameObject obj, script_data* data){
+fluxCallback onInit(fluxGameObject obj, script_data* data, hstrArray args){
     data->y = 0;
 }
 
@@ -183,23 +189,23 @@ void fluxCallback_afterUpdate(fluxGameObject obj, fluxScript script)
 
 
 
-void fluxCallback_onInit(fluxGameObject obj, fluxScript script)
+void fluxCallback_onInit(fluxGameObject obj, fluxScript script, hstrArray args)
 #ifdef FLUX_SCRIPTS_IMPLEMENTATION
 {
     switch(script->id){
         
         case fluxScript_test:
-            test_fluxCallback_onInit(obj,script->test_fluxData);
+            test_fluxCallback_onInit(obj,script->test_fluxData,args);
             break;
 
 
         case fluxScript_lightmanager:
-            lightmanager_fluxCallback_onInit(obj,script->lightmanager_fluxData);
+            lightmanager_fluxCallback_onInit(obj,script->lightmanager_fluxData,args);
             break;
 
 
         case fluxScript_test2:
-            test2_fluxCallback_onInit(obj,script->test2_fluxData);
+            test2_fluxCallback_onInit(obj,script->test2_fluxData,args);
             break;
 
         default:

--- a/src/engine/GENERATED_SCRIPTS.h
+++ b/src/engine/GENERATED_SCRIPTS.h
@@ -1,5 +1,6 @@
 
 struct test_fluxData;
+struct lightmanager_fluxData;
 struct test2_fluxData;
 #define FLUX_GAMEOBJECT_TYPE_ONLY
 #include "gameobject.h"
@@ -14,10 +15,62 @@ script_data{
 
 fluxCallback onInit(fluxGameObject obj, script_data* data){
     data->x = 0;
+    /*render_set_ka(0.2);
+    render_light_enable(0);
+    render_light_set_type(0,0);
+    render_light_set_cL(0,WHITE);
+    render_light_set_kd(0,0.7);
+    render_light_set_ks(0,0.3);
+    render_light_set_L(0,Vector3One());
+    render_light_set_p(0,200);
+
+    render_light_enable(1);
+    render_light_set_type(1,0);
+    render_light_set_cL(1,WHITE);
+    render_light_set_kd(1,0.7);
+    render_light_set_ks(1,0.3);
+    render_light_set_L(1,(Vector3){0,2,-1});
+    render_light_set_p(1,200);*/
 }
 
 fluxCallback onUpdate(fluxGameObject obj, script_data* data){
+    //TraceLog(LOG_INFO,"UPDATE...");
     data->x++;
+}
+
+fluxCallback afterUpdate(fluxGameObject obj, script_data* data){}
+fluxCallback onDestroy(fluxGameObject obj, script_data* data){}
+fluxCallback onDraw(fluxGameObject obj, script_data* data){}
+fluxCallback onDraw2D(fluxGameObject obj, script_data* data){}
+
+#define SCRIPT lightmanager
+#include "fluxScript.h"
+
+script_data{
+
+};
+
+fluxCallback onInit(fluxGameObject obj, script_data* data){
+    render_set_ka(0.2);
+    render_light_enable(0);
+    render_light_set_type(0,0);
+    render_light_set_cL(0,WHITE);
+    render_light_set_kd(0,0.7);
+    render_light_set_ks(0,0.3);
+    render_light_set_L(0,Vector3One());
+    render_light_set_p(0,200);
+
+    render_light_enable(1);
+    render_light_set_type(1,0);
+    render_light_set_cL(1,WHITE);
+    render_light_set_kd(1,0.7);
+    render_light_set_ks(1,0.3);
+    render_light_set_L(1,(Vector3){0,2,-1});
+    render_light_set_p(1,200);
+}
+
+fluxCallback onUpdate(fluxGameObject obj, script_data* data){
+
 }
 
 fluxCallback afterUpdate(fluxGameObject obj, script_data* data){}
@@ -36,7 +89,11 @@ fluxCallback onInit(fluxGameObject obj, script_data* data){
     data->y = 0;
 }
 
-fluxCallback onUpdate(fluxGameObject obj, script_data* data){}
+fluxCallback onUpdate(fluxGameObject obj, script_data* data){
+    //TraceLog(LOG_INFO,"update2");
+    data->y = 0;
+}
+
 fluxCallback afterUpdate(fluxGameObject obj, script_data* data){}
 fluxCallback onDestroy(fluxGameObject obj, script_data* data){}
 fluxCallback onDraw(fluxGameObject obj, script_data* data){}
@@ -45,7 +102,7 @@ fluxCallback onDraw2D(fluxGameObject obj, script_data* data){}
 
 #endif
 
-enum fluxScriptID{fluxEmptyScript,fluxScript_test,fluxScript_test2};
+enum fluxScriptID{fluxEmptyScript,fluxScript_test,fluxScript_lightmanager,fluxScript_test2};
 
 
 struct fluxScriptStruct;
@@ -56,6 +113,7 @@ struct fluxScriptStruct{
     union {
         void* raw;
         struct test_fluxData* test_fluxData;
+        struct lightmanager_fluxData* lightmanager_fluxData;
         struct test2_fluxData* test2_fluxData;
     };
 };
@@ -70,6 +128,11 @@ void fluxCallback_onUpdate(fluxGameObject obj, fluxScript script)
         
         case fluxScript_test:
             test_fluxCallback_onUpdate(obj,script->test_fluxData);
+            break;
+
+
+        case fluxScript_lightmanager:
+            lightmanager_fluxCallback_onUpdate(obj,script->lightmanager_fluxData);
             break;
 
 
@@ -99,6 +162,11 @@ void fluxCallback_afterUpdate(fluxGameObject obj, fluxScript script)
             break;
 
 
+        case fluxScript_lightmanager:
+            lightmanager_fluxCallback_afterUpdate(obj,script->lightmanager_fluxData);
+            break;
+
+
         case fluxScript_test2:
             test2_fluxCallback_afterUpdate(obj,script->test2_fluxData);
             break;
@@ -122,6 +190,11 @@ void fluxCallback_onInit(fluxGameObject obj, fluxScript script)
         
         case fluxScript_test:
             test_fluxCallback_onInit(obj,script->test_fluxData);
+            break;
+
+
+        case fluxScript_lightmanager:
+            lightmanager_fluxCallback_onInit(obj,script->lightmanager_fluxData);
             break;
 
 
@@ -151,6 +224,11 @@ void fluxCallback_onDestroy(fluxGameObject obj, fluxScript script)
             break;
 
 
+        case fluxScript_lightmanager:
+            lightmanager_fluxCallback_onDestroy(obj,script->lightmanager_fluxData);
+            break;
+
+
         case fluxScript_test2:
             test2_fluxCallback_onDestroy(obj,script->test2_fluxData);
             break;
@@ -174,6 +252,11 @@ void fluxCallback_onDraw(fluxGameObject obj, fluxScript script)
         
         case fluxScript_test:
             test_fluxCallback_onDraw(obj,script->test_fluxData);
+            break;
+
+
+        case fluxScript_lightmanager:
+            lightmanager_fluxCallback_onDraw(obj,script->lightmanager_fluxData);
             break;
 
 
@@ -203,6 +286,11 @@ void fluxCallback_onDraw2D(fluxGameObject obj, fluxScript script)
             break;
 
 
+        case fluxScript_lightmanager:
+            lightmanager_fluxCallback_onDraw2D(obj,script->lightmanager_fluxData);
+            break;
+
+
         case fluxScript_test2:
             test2_fluxCallback_onDraw2D(obj,script->test2_fluxData);
             break;
@@ -228,6 +316,9 @@ fluxScript flux_allocate_script(enum fluxScriptID id)
         case fluxScript_test:
             sz = sizeof(struct test_fluxData);
             break;
+        case fluxScript_lightmanager:
+            sz = sizeof(struct lightmanager_fluxData);
+            break;
         case fluxScript_test2:
             sz = sizeof(struct test2_fluxData);
             break;
@@ -244,5 +335,5 @@ fluxScript flux_allocate_script(enum fluxScriptID id)
 
 
 #ifdef FLUX_SCRIPTS_IMPLEMENTATION
-static const char* SCRIPT_NAME_TO_ENUM[3]={[fluxEmptyScript] = "empty_script",[fluxScript_test] = "test",[fluxScript_test2] = "test2"};
+static const char* SCRIPT_NAME_TO_ENUM[4]={[fluxEmptyScript] = "empty_script",[fluxScript_test] = "test",[fluxScript_lightmanager] = "lightmanager",[fluxScript_test2] = "test2"};
 #endif

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -2,6 +2,7 @@
 #include "editor.h"
 #include "hqtools/hqtools.h"
 #include "scene.h"
+#include "pipeline.h"
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -27,6 +28,9 @@ int run_game() {
     editor_add_console_command("quit", console_command_quit);
 
     flux_init_game_callbacks();
+
+    render_init();
+
     // flux_init_prefabs();
     flux_reset_scene();
     flux_game_load();
@@ -38,6 +42,8 @@ int run_game() {
     camera_transform.pos = (Vector3){0, 1, -3};
     camera_transform.rot = (Vector3){-0.3, 0, 0};
     camera_transform.scale = Vector3One();
+
+    render_set_ka(0.2);
 
     // flux_scene_instantiate_prefab(fluxPrefab_defaultCamera,
     // camera_transform); flux_scene_instantiate_prefab(fluxPrefab_testPrefab,
@@ -57,6 +63,7 @@ int run_game() {
 
     flux_close_scene();
     flux_game_close();
+    render_close();
 
     CloseWindow();
 

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -37,19 +37,22 @@ int run_game() {
 
     flux_load_scene("/Users/humzaqureshi/GitHub/Flux-Engine/project/scenes/testScene.scene");
 
-
     fluxTransform camera_transform;
     camera_transform.pos = (Vector3){0, 1, -3};
     camera_transform.rot = (Vector3){-0.3, 0, 0};
     camera_transform.scale = Vector3One();
 
-    render_set_ka(0.2);
+    //render_set_ka(0.2);
 
     // flux_scene_instantiate_prefab(fluxPrefab_defaultCamera,
     // camera_transform); flux_scene_instantiate_prefab(fluxPrefab_testPrefab,
     //                              flux_empty_transform());
 
     while (!WindowShouldClose() && !do_quit) {
+
+        flux_scene_script_callback(ONUPDATE);
+        flux_scene_script_callback(AFTERUPDATE);
+
         BeginDrawing();
 
         ClearBackground(BLACK);

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -31,22 +31,10 @@ int run_game() {
 
     render_init();
 
-    // flux_init_prefabs();
     flux_reset_scene();
     flux_game_load();
 
     flux_load_scene("/Users/humzaqureshi/GitHub/Flux-Engine/project/scenes/testScene.scene");
-
-    fluxTransform camera_transform;
-    camera_transform.pos = (Vector3){0, 1, -3};
-    camera_transform.rot = (Vector3){-0.3, 0, 0};
-    camera_transform.scale = Vector3One();
-
-    //render_set_ka(0.2);
-
-    // flux_scene_instantiate_prefab(fluxPrefab_defaultCamera,
-    // camera_transform); flux_scene_instantiate_prefab(fluxPrefab_testPrefab,
-    //                              flux_empty_transform());
 
     while (!WindowShouldClose() && !do_quit) {
 
@@ -54,8 +42,6 @@ int run_game() {
         flux_scene_script_callback(AFTERUPDATE);
 
         BeginDrawing();
-
-        ClearBackground(BLACK);
 
         flux_draw_scene();
 

--- a/src/engine/fluxScript.h
+++ b/src/engine/fluxScript.h
@@ -1,4 +1,5 @@
 #include "gameobject.h"
+#include "hqtools/hqtools.h"
 #include <assert.h>
 
 #define fluxConcat_(X, Y) X##_##Y

--- a/src/engine/gameobject.c
+++ b/src/engine/gameobject.c
@@ -107,6 +107,13 @@ fluxGameObject flux_allocate_gameobject(int id, fluxTransform transform, fluxPre
     return out;
 }
 
+fluxScript flux_gameobject_get_script(fluxGameObject obj, int i){
+    assert(obj);
+    assert(i >= 0);
+    assert(i < obj->n_scripts);
+    return obj->scripts[i];
+}
+
 void flux_destroy_gameobject(fluxGameObject obj){
     assert(obj);
     if (obj->scripts){

--- a/src/engine/gameobject.c
+++ b/src/engine/gameobject.c
@@ -87,7 +87,7 @@ Camera3D flux_gameobject_get_raylib_camera(fluxGameObject obj){
     return out;
 }
 
-fluxGameObject flux_allocate_gameobject(int id, fluxTransform transform, fluxPrefab prefab){
+fluxGameObject flux_allocate_gameobject(int id, fluxTransform transform, fluxPrefab prefab, hstrArray args){
     fluxGameObject out;
     assert(out = malloc(sizeof(struct fluxGameObjectStruct)));
     out->id = id;
@@ -100,6 +100,7 @@ fluxGameObject flux_allocate_gameobject(int id, fluxTransform transform, fluxPre
         assert(out->scripts = malloc(sizeof(fluxScript) * out->n_scripts));
         for (int i = 0; i < out->n_scripts; i++){
             out->scripts[i] = flux_allocate_script(flux_prefab_get_scripts(prefab)[i]);
+            fluxCallback_onInit(out,out->scripts[i],args);
         }
     }
     out->fov = flux_prefab_get_fov(prefab);

--- a/src/engine/gameobject.c
+++ b/src/engine/gameobject.c
@@ -16,6 +16,8 @@
 #include "rcamera.h"
 #include "sceneallocator.h"
 #include "transform.h"
+#include "pipeline.h"
+#include "prefabs.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -26,196 +28,57 @@
  */
 struct fluxGameObjectStruct {
     int id;           ///< Unique ID of the game object.
-    const char* name; ///< Name of the prefab instance.
-    const char* tag;  ///< Tag of the game object for categorization.
-    struct fluxTransform
-        transform;  ///< Transform of the game object in the scene.
-    bool has_model; ///< Indicates if the game object has a model.
-    Model model;    ///< Model of the game object.
-    Color tint;     ///< Tint color of the model.
-    bool is_camera; ///< Indicates if the game object is a camera.
-    Camera3D cam;   ///< Camera properties if the game object is a camera.
-    int n_scripts;  ///< Number of scripts attached to the game object.
-    fluxScript
-        scripts[FLUX_MAX_SCRIPTS]; ///< Scripts attached to the game object.
-    int n_children;                ///< Number of child objects.
-    struct fluxGameObjectStruct*
-        children[FLUX_MAX_CHILDREN]; ///< Child objects.
+    fluxTransform transform;
+    renderModel model;
+    int n_scripts;
+    fluxScript* scripts;
+    bool is_camera;
+    float fov;
+    int projection;
 };
 
-/**
- * Allocates and initializes a new game object.
- *
- * @param name Name of the new game object.
- * @param tag Tag for the new game object.
- * @param transform Initial transform for the new game object.
- * @return A pointer to the newly allocated game object.
- */
-fluxGameObject flux_allocate_gameobject(const char* name, const char* tag,
-                                        fluxTransform transform) {
-    fluxGameObject out =
-        (fluxGameObject)flux_scene_alloc(sizeof(struct fluxGameObjectStruct));
-    out->id = flux_scene_get_unique_id();
-    out->name = name;
-    out->tag = tag;
-    out->transform = transform;
-    out->has_model = 0;
-    out->is_camera = 0;
-    out->n_children = 0;
-    out->n_scripts = 0;
-    return out;
-}
-
-/**
- * Sets the model and tint for a game object.
- *
- * @param obj Pointer to the game object.
- * @param model Model to set for the game object.
- * @param tint Tint color to apply to the model.
- */
-void flux_gameobject_set_model(fluxGameObject obj, Model model, Color tint) {
-    FLUX_ASSERT((obj != NULL),
-                "FLUX<gameobject.c>: tried to set model of NULL game object!");
-    FLUX_ASSERT(!(obj->is_camera),
-                "FLUX<gameobject.c>: tried to add model to camera!");
-    obj->has_model = 1;
-    obj->model = model;
-    obj->tint = tint;
-}
-
-/**
- * Configures a game object as a camera.
- *
- * @param obj Pointer to the game object.
- * @param fovy Field of view angle in the y direction, in degrees.
- * @param projection Projection type of the camera.
- */
-void flux_gameobject_set_camera(fluxGameObject obj, float fovy,
-                                int projection) {
-    FLUX_ASSERT(obj != NULL,
-                "FLUX<gameobject.c>: tried to set camera of NULL game object!");
-    FLUX_ASSERT(!obj->has_model,
-                "FLUX<gameobject.c>: tried to set camera of model!");
-    obj->is_camera = 1;
-    obj->cam.fovy = fovy;
-    obj->cam.projection = projection;
-}
-
-/**
- * Adds a script to a game object.
- *
- * @param obj Pointer to the game object.
- * @param script ID of the script to add.
- */
-void flux_gameobject_add_script(fluxGameObject obj, enum fluxScriptID script) {
-    FLUX_ASSERT(obj != NULL,
-                "FLUX<gameobject.c>: tried to add script to NULL game object!");
-    FLUX_ASSERT(
-        obj->n_scripts < FLUX_MAX_SCRIPTS,
-        "FLUX<gameobject.c>: game object already has FLUX_MAX_SCRIPTS scripts");
-    obj->scripts[obj->n_scripts] = flux_allocate_script(script);
-    obj->n_scripts++;
-}
-
-/**
- * Adds a child game object.
- *
- * @param obj Pointer to the parent game object.
- * @param child Pointer to the child game object to add.
- */
-void flux_gameobject_add_child(fluxGameObject obj, fluxGameObject child) {
-    FLUX_ASSERT(obj != NULL,
-                "FLUX<gameobject.c>: tried to add child to NULL game object!");
-    FLUX_ASSERT(child != NULL, "FLUX<gameobject.c>: tried to add NULL child!");
-    FLUX_ASSERT(obj->n_children < FLUX_MAX_CHILDREN,
-                "FLUX<gameobject.c>: game object already has FLUX_MAX_CHILDREN "
-                "scripts");
-    obj->children[obj->n_children] = child;
-    obj->n_children++;
-}
-
-/**
- * Checks if a game object is configured as a camera.
- *
- * @param obj Pointer to the game object.
- * @return True if the game object is a camera, otherwise false.
- */
-bool flux_gameobject_is_camera(fluxGameObject obj) {
-    assert(obj);
-    return obj->is_camera;
-}
-
-/**
- * Checks if a game object has a model.
- *
- * @param obj Pointer to the game object.
- * @return True if the game object has a model, otherwise false.
- */
-bool flux_gameobject_has_model(fluxGameObject obj) {
-    assert(obj);
-    return obj->has_model;
-}
-
-/**
- * Retrieves the model of a game object.
- *
- * @param obj Pointer to the game object.
- * @return Model of the game object.
- */
-Model flux_gameobject_get_model(fluxGameObject obj) {
-    assert(flux_gameobject_has_model(obj));
-    return obj->model;
-}
-
-/**
- * Retrieves the transform of a game object.
- *
- * @param obj Pointer to the game object.
- * @return Transform of the game object.
- */
-fluxTransform flux_gameobject_get_transform(fluxGameObject obj) {
-    assert(obj);
-    return obj->transform;
-}
-
-/**
- * Retrieves the tint color of a game object's model.
- *
- * @param obj Pointer to the game object.
- * @return Tint color of the model.
- */
-Color flux_gameobject_get_tint(fluxGameObject obj) {
-    assert(obj);
-    return obj->tint;
-}
-
-/**
- * Retrieves the unique ID of a game object.
- *
- * @param obj Pointer to the game object.
- * @return Unique ID of the game object.
- */
-int flux_gameobject_get_id(fluxGameObject obj) {
+int flux_gameobject_get_id(fluxGameObject obj){
     assert(obj);
     return obj->id;
 }
 
-/**
- * Retrieves the raylib camera configuration of a game object.
- * This function is applicable only if the game object is configured as
- * a camera.
- *
- * @param obj Pointer to the game object.
- * @return A raylib Camera3D structure representing the camera's configuration.
- */
-Camera3D flux_gameobject_get_raylib_camera(fluxGameObject obj) {
-    FLUX_ASSERT(flux_gameobject_is_camera(obj),
-                "FLUX<gameobject.c>: tried to get camera of game object that "
-                "isn't camera");
+fluxTransform flux_gameobject_get_transform(fluxGameObject obj){
+    assert(obj);
+    return obj->transform;
+}
+
+void flux_gameobject_set_transform(fluxGameObject obj, fluxTransform transform){
+    assert(obj);
+    obj->transform = transform;
+}
+
+int flux_gameobject_get_n_scripts(fluxGameObject obj){
+    assert(obj);
+    return obj->n_scripts;
+}
+
+bool flux_gameobject_is_camera(fluxGameObject obj){
+    assert(obj);
+    return obj->is_camera;
+}
+
+renderModel flux_gameobject_get_model(fluxGameObject obj){
+    assert(obj);
+    return obj->model;
+}
+
+bool flux_gameobject_has_model(fluxGameObject obj){
+    assert(obj);
+    return obj->model != NULL;
+}
+
+Camera3D flux_gameobject_get_raylib_camera(fluxGameObject obj){
+    assert(obj);
+    assert(obj->is_camera);
     Camera3D out;
-    out.fovy = obj->cam.fovy;
+    out.fovy = obj->fov;
     out.position = obj->transform.pos;
-    out.projection = obj->cam.projection;
+    out.projection = obj->projection;
     out.up = (Vector3){0.0f, 1.0f, 0.0f};
     out.target = Vector3Add(out.position, (Vector3){0.0f, 0.0f, 1.0f});
     CameraPitch(&out, obj->transform.rot.x, true, false, false);
@@ -224,22 +87,34 @@ Camera3D flux_gameobject_get_raylib_camera(fluxGameObject obj) {
     return out;
 }
 
-void flux_gameobject_draw(fluxGameObject obj) {
-    assert(obj);
-
-    if ((!flux_gameobject_is_camera(obj)) && (flux_gameobject_has_model(obj))) {
-        // TraceLog(LOG_INFO,"drawing model");
-        Model model = flux_gameobject_get_model(obj);
-        fluxTransform transform = flux_gameobject_get_transform(obj);
-        Color tint = flux_gameobject_get_tint(obj);
-        Quaternion qrot =
-            QuaternionFromEuler(Wrap(transform.rot.x, 0, 2 * M_PI),
-                                Wrap(transform.rot.y, 0, 2 * M_PI),
-                                Wrap(transform.rot.z, 0, 2 * M_PI));
-        Vector3 rot_axis;
-        float rot_amount;
-        QuaternionToAxisAngle(qrot, &rot_axis, &rot_amount);
-        DrawModelEx(model, transform.pos, rot_axis, rot_amount, transform.scale,
-                    tint);
+fluxGameObject flux_allocate_gameobject(int id, fluxTransform transform, fluxPrefab prefab){
+    fluxGameObject out;
+    assert(out = malloc(sizeof(struct fluxGameObjectStruct)));
+    out->id = id;
+    out->transform = transform;
+    out->model = flux_prefab_get_model(prefab);
+    out->n_scripts = flux_prefab_get_n_scripts(prefab);
+    out->scripts = NULL;
+    out->is_camera = flux_prefab_is_camera(prefab);
+    if (out->n_scripts != 0){
+        assert(out->scripts = malloc(sizeof(fluxScript) * out->n_scripts));
+        for (int i = 0; i < out->n_scripts; i++){
+            out->scripts[i] = flux_allocate_script(flux_prefab_get_scripts(prefab)[i]);
+        }
     }
+    out->fov = flux_prefab_get_fov(prefab);
+    out->projection = flux_prefab_get_projection(prefab);
+    return out;
+}
+
+void flux_destroy_gameobject(fluxGameObject obj){
+    assert(obj);
+    if (obj->scripts){
+        assert(obj->n_scripts > 0);
+        // scene allocator should free script data?
+        free(obj->scripts);
+    } else {
+        assert(obj->n_scripts == 0);
+    }
+    free(obj);
 }

--- a/src/engine/gameobject.h
+++ b/src/engine/gameobject.h
@@ -13,32 +13,29 @@ typedef struct fluxGameObjectStruct* fluxGameObject;
 
 #include "scripts.h"
 
-fluxGameObject flux_allocate_gameobject(const char* name, const char* tag,
-                                        fluxTransform transform);
+#include "pipeline.h"
 
-void flux_gameobject_set_model(fluxGameObject obj, Model model, Color tint);
+#include "prefabs.h"
 
-void flux_gameobject_set_camera(fluxGameObject obj, float fovy, int projection);
+fluxGameObject flux_allocate_gameobject(int id, fluxTransform transform, fluxPrefab prefab);
 
-void flux_gameobject_add_script(fluxGameObject obj, enum fluxScriptID script);
-
-void flux_gameobject_add_child(fluxGameObject obj, fluxGameObject child);
-
-bool flux_gameobject_is_camera(fluxGameObject obj);
-
-bool flux_gameobject_has_model(fluxGameObject obj);
+void flux_destroy_gameobject(fluxGameObject obj);
 
 int flux_gameobject_get_id(fluxGameObject obj);
 
-Model flux_gameobject_get_model(fluxGameObject obj);
-
 fluxTransform flux_gameobject_get_transform(fluxGameObject obj);
 
-Color flux_gameobject_get_tint(fluxGameObject obj);
+void flux_gameobject_set_transform(fluxGameObject obj, fluxTransform transform);
+
+int flux_gameobject_get_n_scripts(fluxGameObject obj);
+
+bool flux_gameobject_is_camera(fluxGameObject obj);
+
+renderModel flux_gameobject_get_model(fluxGameObject obj);
+
+bool flux_gameobject_has_model(fluxGameObject obj);
 
 Camera3D flux_gameobject_get_raylib_camera(fluxGameObject obj);
-
-void flux_gameobject_draw(fluxGameObject obj);
 
 #endif
 #endif

--- a/src/engine/gameobject.h
+++ b/src/engine/gameobject.h
@@ -37,5 +37,7 @@ bool flux_gameobject_has_model(fluxGameObject obj);
 
 Camera3D flux_gameobject_get_raylib_camera(fluxGameObject obj);
 
+fluxScript flux_gameobject_get_script(fluxGameObject obj, int i);
+
 #endif
 #endif

--- a/src/engine/gameobject.h
+++ b/src/engine/gameobject.h
@@ -1,9 +1,16 @@
 #ifndef _FLUX_GAMEOBJECT_H_
 #define _FLUX_GAMEOBJECT_H_
 
+#include "transform.h"
+#include "hqtools/hqtools.h"
+
 // gameobject struct
 struct fluxGameObjectStruct;
 typedef struct fluxGameObjectStruct* fluxGameObject;
+
+fluxTransform flux_gameobject_get_transform(fluxGameObject obj);
+
+void flux_gameobject_set_transform(fluxGameObject obj, fluxTransform transform);
 
 #ifndef FLUX_GAMEOBJECT_TYPE_ONLY
 
@@ -17,15 +24,11 @@ typedef struct fluxGameObjectStruct* fluxGameObject;
 
 #include "prefabs.h"
 
-fluxGameObject flux_allocate_gameobject(int id, fluxTransform transform, fluxPrefab prefab);
+fluxGameObject flux_allocate_gameobject(int id, fluxTransform transform, fluxPrefab prefab, hstrArray args);
 
 void flux_destroy_gameobject(fluxGameObject obj);
 
 int flux_gameobject_get_id(fluxGameObject obj);
-
-fluxTransform flux_gameobject_get_transform(fluxGameObject obj);
-
-void flux_gameobject_set_transform(fluxGameObject obj, fluxTransform transform);
 
 int flux_gameobject_get_n_scripts(fluxGameObject obj);
 

--- a/src/engine/prefabs.c
+++ b/src/engine/prefabs.c
@@ -14,7 +14,64 @@ typedef struct fluxPrefabStruct {
     bool is_camera;
     int n_scripts;
     enum fluxScriptID* scripts;
+    int projection;
+    float fov;
 } fluxPrefabStruct;
+
+hstr flux_prefab_get_name(fluxPrefab prefab){
+    assert(prefab);
+    return prefab->name;
+}
+
+int flux_prefab_get_projection(fluxPrefab prefab){
+    assert(prefab);
+    return prefab->projection;
+}
+
+void flux_prefab_set_projection(fluxPrefab prefab, int projection){
+    assert(prefab);
+    prefab->projection = projection;
+}
+
+float flux_prefab_get_fov(fluxPrefab prefab){
+    assert(prefab);
+    return prefab->fov;
+}
+
+void flux_prefab_set_fov(fluxPrefab prefab, float fov){
+    assert(prefab);
+    prefab->fov = fov;
+}
+
+bool flux_prefab_has_model(fluxPrefab prefab){
+    assert(prefab);
+    return prefab->has_model;
+}
+
+Model flux_prefab_get_raw_model(fluxPrefab prefab){
+    assert(prefab);
+    return prefab->raw_model;
+}
+
+renderModel flux_prefab_get_model(fluxPrefab prefab){
+    assert(prefab);
+    return prefab->model;
+}
+
+bool flux_prefab_is_camera(fluxPrefab prefab){
+    assert(prefab);
+    return prefab->is_camera;
+}
+
+int flux_prefab_get_n_scripts(fluxPrefab prefab){
+    assert(prefab);
+    return prefab->n_scripts;
+}
+
+enum fluxScriptID* flux_prefab_get_scripts(fluxPrefab prefab){
+    assert(prefab);
+    return prefab->scripts;
+}
 
 fluxPrefab flux_load_prefab(fluxParsedPrefab parsed) {
     assert(parsed);
@@ -23,9 +80,12 @@ fluxPrefab flux_load_prefab(fluxParsedPrefab parsed) {
     memset(out, 0, sizeof(fluxPrefabStruct));
     out->name = hstr_incref(parser_parsed_prefab_get_name(parsed));
     out->has_model = parser_parsed_prefab_has_model(parsed);
+    //out->raw_model = NULL;
+    out->model = NULL;
     if (out->has_model) {
         const char* model_path =
             hstr_unpack(parser_parsed_prefab_get_model_path(parsed));
+        TraceLog(LOG_INFO,"loading model %s",model_path);
         if (strcmp(model_path, "SPHERE") == 0) {
             out->raw_model = LoadModelFromMesh(GenMeshSphere(1, 10, 10));
         } else {
@@ -41,6 +101,8 @@ fluxPrefab flux_load_prefab(fluxParsedPrefab parsed) {
         out->scripts[i] =
             flux_script_name_to_enum(hstr_unpack(hstr_array_get(scripts, i)));
     }
+    out->projection = parser_parsed_prefab_get_projection(parsed);
+    out->fov = parser_parsed_prefab_get_fov(parsed);
     return out;
 }
 

--- a/src/engine/prefabs.c
+++ b/src/engine/prefabs.c
@@ -87,7 +87,7 @@ fluxPrefab flux_load_prefab(fluxParsedPrefab parsed) {
             hstr_unpack(parser_parsed_prefab_get_model_path(parsed));
         TraceLog(LOG_INFO,"loading model %s",model_path);
         if (strcmp(model_path, "SPHERE") == 0) {
-            out->raw_model = LoadModelFromMesh(GenMeshSphere(1, 10, 10));
+            out->raw_model = LoadModelFromMesh(GenMeshSphere(1, 50, 50));
         } else {
             out->raw_model = LoadModel(model_path);
         }

--- a/src/engine/prefabs.h
+++ b/src/engine/prefabs.h
@@ -2,6 +2,8 @@
 #define _FLUX_PREFABS_H_
 
 #include "prefab_parser.h"
+#include "pipeline.h"
+#include "scripts.h"
 
 struct fluxPrefabStruct;
 typedef struct fluxPrefabStruct* fluxPrefab;
@@ -9,5 +11,27 @@ typedef struct fluxPrefabStruct* fluxPrefab;
 fluxPrefab flux_load_prefab(fluxParsedPrefab parsed);
 
 void flux_delete_prefab(fluxPrefab prefab);
+
+hstr flux_prefab_get_name(fluxPrefab prefab);
+
+bool flux_prefab_has_model(fluxPrefab prefab);
+
+Model flux_prefab_get_raw_model(fluxPrefab prefab);
+
+renderModel flux_prefab_get_model(fluxPrefab prefab);
+
+bool flux_prefab_is_camera(fluxPrefab prefab);
+
+int flux_prefab_get_n_scripts(fluxPrefab prefab);
+
+int flux_prefab_get_projection(fluxPrefab prefab);
+
+void flux_prefab_set_projection(fluxPrefab prefab, int projection);
+
+float flux_prefab_get_fov(fluxPrefab prefab);
+
+void flux_prefab_set_fov(fluxPrefab prefab, float fov);
+
+enum fluxScriptID* flux_prefab_get_scripts(fluxPrefab prefab);
 
 #endif

--- a/src/engine/scene.c
+++ b/src/engine/scene.c
@@ -80,7 +80,7 @@ void flux_load_scene(const char* path) {
         assert(to_instantiate != NULL);
         hstr_decref(prefab_name);
 
-        fluxGameObject allocated = flux_allocate_gameobject(i,transform,to_instantiate);
+        fluxGameObject allocated = flux_allocate_gameobject(i,transform,to_instantiate, parser_parsed_gameobject_get_args(parsed_gameobject));
 
         if (flux_gameobject_is_camera(allocated) && (active_camera == NULL)){
             active_camera = allocated;
@@ -92,8 +92,6 @@ void flux_load_scene(const char* path) {
     }
 
     parser_delete_parsed_scene(parsed_scene);
-
-    flux_scene_script_callback(ONINIT);
 }
 
 void flux_scene_script_callback(script_callback_t callback){
@@ -105,9 +103,9 @@ void flux_scene_script_callback(script_callback_t callback){
         case AFTERUPDATE:
             func = fluxCallback_afterUpdate;
             break;
-        case ONINIT:
-            func = fluxCallback_onInit;
-            break;
+        //case ONINIT:
+        //    func = fluxCallback_onInit;
+        //    break;
         case ONDESTROY:
             func = fluxCallback_onDestroy;
             break;

--- a/src/engine/scene.c
+++ b/src/engine/scene.c
@@ -13,11 +13,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-static fluxGameObject game_objects[FLUX_MAX_GAMEOBJECTS];
+static fluxGameObject* game_objects;
 static fluxPrefab* prefabs = NULL;
 static int n_prefabs = 0;
 static int n_objects = 0;
-static fluxGameObject active_camera;
+static fluxGameObject active_camera = NULL;
 
 void flux_reset_scene(void) {
     flux_init_scene_allocator();
@@ -34,6 +34,14 @@ void flux_close_scene(void) {
         prefabs = NULL;
         n_prefabs = 0;
     }
+    if (game_objects){
+        for (int i = 0; i < n_objects; i++){
+            flux_destroy_gameobject(game_objects[i]);
+        }
+        free(game_objects);
+        game_objects = NULL;
+        n_objects = 0;
+    }
     flux_close_scene_allocator();
 }
 
@@ -43,6 +51,8 @@ void flux_load_scene(const char* path) {
     assert(n_prefabs == 0);
     TraceLog(LOG_INFO,"loading scene %s",path);
     fluxParsedScene parsed_scene = parser_read_scene(path);
+
+    active_camera = NULL;
 
     TraceLog(LOG_INFO,"scene name: %s",hstr_unpack(parser_parsed_scene_get_name(parsed_scene)));
 
@@ -54,13 +64,67 @@ void flux_load_scene(const char* path) {
         n_prefabs++;
     }
 
+    for (int i = 0; i < parser_parsed_scene_get_n_gameobjects(parsed_scene); i++){
+        fluxParsedGameObject parsed_gameobject = parser_parsed_scene_get_gameobject(parsed_scene,i);
+        fluxTransform transform = parser_parsed_gameobject_get_transform(parsed_gameobject);
+        hstr prefab_name = hstr_incref(parser_parsed_gameobject_get_prefab_name(parsed_gameobject));
+        fluxPrefab to_instantiate = NULL;
+        for (int j = 0; j < n_prefabs; j++){
+            fluxPrefab prefab = prefabs[i];
+            if (strcmp(hstr_unpack(flux_prefab_get_name(prefab)),hstr_unpack(prefab_name)) != 0)continue;
+            to_instantiate = prefab;
+        }
+
+        assert(to_instantiate != NULL);
+        hstr_decref(prefab_name);
+
+        fluxGameObject allocated = flux_allocate_gameobject(i,transform,to_instantiate);
+
+        if (flux_gameobject_is_camera(allocated) && (active_camera == NULL)){
+            active_camera = allocated;
+        }
+
+        game_objects = realloc(game_objects, sizeof(fluxGameObject) * (n_objects + 1));
+        game_objects[n_objects] = allocated;
+        n_objects++;
+    }
+
     parser_delete_parsed_scene(parsed_scene);
 }
 
 void flux_draw_scene(void) {
     if (!active_camera)
         return;
+
+    for (int i = 0; i < n_prefabs; i++){
+        if (flux_prefab_is_camera(prefabs[i]))continue;
+        if (flux_prefab_get_model(prefabs[i]) == NULL)continue;
+        render_reset_instances(flux_prefab_get_model(prefabs[i]));
+    }
+
+    for (int i = 0; i < n_objects; i++){
+        fluxGameObject obj = game_objects[i];
+        if (flux_gameobject_is_camera(obj))continue;
+        if (!flux_gameobject_has_model(obj))continue;
+        render_add_model_instance(flux_gameobject_get_model(obj),flux_gameobject_get_transform(obj));
+    }
+
     Camera3D cam = flux_gameobject_get_raylib_camera(active_camera);
+
+    render_begin(cam);
+
+    for (int i = 0; i < n_prefabs; i++){
+        if (flux_prefab_is_camera(prefabs[i]))continue;
+        if (flux_prefab_get_model(prefabs[i]) == NULL)continue;
+        render_rmodel(flux_prefab_get_model(prefabs[i]),WHITE);
+    }
+
+    render_calculate_shadows();
+
+    render_end();
+
+    //TraceLog(LOG_INFO,"camera found");
+    /*Camera3D cam = flux_gameobject_get_raylib_camera(active_camera);
     TraceLog(LOG_DEBUG,
              "FLUX<scene.c>: drawing scene with camera: position = {%g %g %g}, "
              "target = {%g %g %g}, up = {%g %g %g}, fovy = %g, projection = %d",
@@ -74,5 +138,5 @@ void flux_draw_scene(void) {
         // flux_gameobject_draw(game_objects[i]);
     }
 
-    EndMode3D();
+    EndMode3D();*/
 }

--- a/src/engine/scene.c
+++ b/src/engine/scene.c
@@ -158,6 +158,8 @@ void flux_draw_scene(void) {
 
     render_end();
 
+    flux_scene_script_callback(ONDRAW2D);
+
     //TraceLog(LOG_INFO,"camera found");
     /*Camera3D cam = flux_gameobject_get_raylib_camera(active_camera);
     TraceLog(LOG_DEBUG,

--- a/src/engine/scene.h
+++ b/src/engine/scene.h
@@ -7,7 +7,6 @@
 typedef enum{
     ONUPDATE,
     AFTERUPDATE,
-    ONINIT,
     ONDESTROY,
     ONDRAW,
     ONDRAW2D

--- a/src/engine/scene.h
+++ b/src/engine/scene.h
@@ -4,6 +4,15 @@
 // #include "prefabs.h"
 #include "transform.h"
 
+typedef enum{
+    ONUPDATE,
+    AFTERUPDATE,
+    ONINIT,
+    ONDESTROY,
+    ONDRAW,
+    ONDRAW2D
+} script_callback_t;
+
 void flux_load_scene(const char* path);
 
 void flux_reset_scene(void);
@@ -11,5 +20,7 @@ void flux_reset_scene(void);
 void flux_close_scene(void);
 
 void flux_draw_scene(void);
+
+void flux_scene_script_callback(script_callback_t callback);
 
 #endif

--- a/src/engine/scripts.c
+++ b/src/engine/scripts.c
@@ -1,4 +1,5 @@
 #include "hqtools/hqtools.h"
+#include "pipeline.h"
 
 #include <string.h>
 

--- a/src/engine/scripts.h
+++ b/src/engine/scripts.h
@@ -1,6 +1,8 @@
 #ifndef _FLUX_SCRIPTS_H_
 #define _FLUX_SCRIPTS_H_
 
+#include "hqtools/hqtools.h"
+
 #undef FLUX_SCRIPTS_IMPLEMENTATION
 #include "GENERATED_SCRIPTS.h"
 

--- a/src/parsers/prefab_parser.c
+++ b/src/parsers/prefab_parser.c
@@ -25,6 +25,9 @@ typedef struct fluxParsedPrefabStruct {
     /*! \brief whether this prefab is a camera */
     bool is_camera;
 
+    float fov;
+    int projection;
+
     /*! \brief the names of any scripts attached to this prefab */
     hstrArray scripts;
 
@@ -32,6 +35,26 @@ typedef struct fluxParsedPrefabStruct {
     hstrArray children;
 
 } fluxParsedPrefabStruct;
+
+float parser_parsed_prefab_get_fov(fluxParsedPrefab prefab){
+    assert(prefab);
+    return prefab->fov;
+}
+
+int parser_parsed_prefab_get_projection(fluxParsedPrefab prefab){
+    assert(prefab);
+    return prefab->projection;
+}
+
+void parser_parsed_prefab_set_fov(fluxParsedPrefab prefab, float fov){
+    assert(prefab);
+    prefab->fov = fov;
+}
+
+void parser_parsed_prefab_set_projection(fluxParsedPrefab prefab, int projection){
+    assert(prefab);
+    prefab->projection = projection;
+}
 
 hstr parser_parsed_prefab_get_path(fluxParsedPrefab prefab) {
     assert(prefab);
@@ -69,6 +92,8 @@ static fluxParsedPrefab alloc_parsed_prefab_internal(void) {
     memset(out, 0, sizeof(fluxParsedPrefabStruct));
     out->scripts = hstr_array_make();
     out->children = hstr_array_make();
+    out->fov = 45;
+    out->projection = CAMERA_PERSPECTIVE;
     return out;
 }
 

--- a/src/parsers/prefab_parser.h
+++ b/src/parsers/prefab_parser.h
@@ -21,4 +21,12 @@ bool parser_parsed_prefab_is_camera(fluxParsedPrefab prefab);
 
 hstrArray parser_parsed_prefab_get_scripts(fluxParsedPrefab prefab);
 
+float parser_parsed_prefab_get_fov(fluxParsedPrefab prefab);
+
+int parser_parsed_prefab_get_projection(fluxParsedPrefab prefab);
+
+void parser_parsed_prefab_set_fov(fluxParsedPrefab prefab, float fov);
+
+void parser_parsed_prefab_set_projection(fluxParsedPrefab prefab, int projection);
+
 #endif

--- a/src/parsers/scene_parser.h
+++ b/src/parsers/scene_parser.h
@@ -30,4 +30,6 @@ hstr parser_parsed_gameobject_get_prefab_name(fluxParsedGameObject gameobject);
 fluxTransform
 parser_parsed_gameobject_get_transform(fluxParsedGameObject gameobject);
 
+hstrArray parser_parsed_gameobject_get_args(fluxParsedGameObject gameobject);
+
 #endif

--- a/src/renderer/pipeline.c
+++ b/src/renderer/pipeline.c
@@ -154,6 +154,7 @@ renderModel render_make_model(Model model) {
         out->mesh_bounding_boxes[i] =
             bbox2better(GetMeshBoundingBox(model.meshes[i]));
     }
+    TraceLog(LOG_INFO,"made model, %d meshes",model.meshCount);
     return out;
 }
 
@@ -191,6 +192,7 @@ void render_add_model_instance(renderModel model, fluxTransform transform) {
     model->transforms[model->n_instances] =
         get_mesh_transform(model->model, transform);
     model->n_instances++;
+    //TraceLog(LOG_INFO,"adding model instances, %g %g %g, %g %g %g, %g %g %g",transform.pos.x,transform.pos.y,transform.pos.z,transform.rot.x,transform.rot.y,transform.rot.z,transform.scale.x,transform.scale.y,transform.scale.z);
 }
 
 void render_rmodel(renderModel rmodel, Color tint) {
@@ -268,7 +270,6 @@ static void draw_rmodel(renderModel rmodel, Shader shader, Camera3D camera,
                 visible_meshes++;
                 DrawMesh(model.meshes[i],
                          model.materials[model.meshMaterial[i]], transform);
-                // drawBBox(transformed);
             }
         }
 

--- a/src/renderer/shader_manager.c
+++ b/src/renderer/shader_manager.c
@@ -178,6 +178,7 @@ void render_unload_skybox(void) {
 void render_draw_skybox(void) {
     if (!skybox_loaded)
         return;
+    //TraceLog(LOG_INFO,"rendering skybox");
     rlDisableBackfaceCulling();
     rlDisableDepthMask();
     DrawModel(skybox, render_get_current_cam().position, 1.0f, WHITE);


### PR DESCRIPTION
* scene parser now parses gameobjects
* scripts get called when they should (only onInit, onDestroy, onUpdate, afterUpdate and onDraw2D for now, unsure if onDraw makes sense now).
* extra args specified in the scene file are now passed to gameobjects as an hstrArray.
* light manager now lets you specify ka/skybox path in the scene file.